### PR TITLE
Pass CORS config to the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Options:
   -d, --database            SQLite database file or :memory: [string] [required]
   -p, --port                Port to listen on                           [number]
   -r, --rate-limit-enabled  Enable rate limiting                       [boolean]
-  -c, --cors                CORS white list URL values                 [string]
+  -c, --cors                CORS whitelist origins                [string]
       --help                Show help                                  [boolean]
 
 ```

--- a/README.md
+++ b/README.md
@@ -8,15 +8,18 @@
 [![justforfunnoreally.dev badge](https://img.shields.io/badge/justforfunnoreally-dev-9ff)](https://justforfunnoreally.dev)
 
 ## Installation
+
 Install Soul CLI with npm
 
 ```bash
   npm install -g soul-cli
 ```
-    
+
 ## Usage
+
 Soul is command line tool, after installing it,
-Run ```soul -d sqlite.db -p 8000``` and it'll start a REST API on [http://localhost:8000](http://localhost:8000) and a Websocket server on [ws://localhost:8000](ws://localhost:8000).
+Run `soul -d sqlite.db -p 8000` and it'll start a REST API on [http://localhost:8000](http://localhost:8000) and a Websocket server on [ws://localhost:8000](ws://localhost:8000).
+
 ```bash
 Usage: soul [options]
 
@@ -26,14 +29,17 @@ Options:
   -d, --database            SQLite database file or :memory: [string] [required]
   -p, --port                Port to listen on                           [number]
   -r, --rate-limit-enabled  Enable rate limiting                       [boolean]
+  -c, --cors                CORS white list URL values                 [string]
       --help                Show help                                  [boolean]
 
 ```
 
 Then to test Soul is working run the following command
+
 ```bash
 curl http://localhost:8000/api/tables
 ```
+
 It should return a list of the tables inside `sqlite.db` database.
 
 ## Documentation
@@ -79,6 +85,7 @@ npm run dev # Start the dev server
 ### Studio
 
 Make sure that Soul Core API is up and running and then
+
 ```bash
 cd studio # Move into the studio directory
 
@@ -93,18 +100,15 @@ npm run dev # Start the dev server
 
 [Join](https://bit.ly/soul-discord) the discussion in our Discord server and help making Soul together.
 
-
 ## Contributing
 
 Contributions are always welcome!
 
 See `CONTRIBUTING.md` for ways to get started and please adhere to `CODE OF CONDUCT`.
 
-
 ## Authors
 
 - [@thevahidal](https://www.github.com/thevahidal)
-
 
 ## License
 

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "soul-cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "soul-cli",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^8.1.0",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soul-cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A SQLite REST and Realtime server",
   "main": "src/server.js",
   "bin": {

--- a/core/src/cli.js
+++ b/core/src/cli.js
@@ -29,7 +29,7 @@ if (process.env.NO_CLI !== 'true') {
     })
     .option('c', {
       alias: 'cors',
-      describe: 'CORS white list URLs',
+      describe: 'CORS whitelist origins',
       type: 'string',
       demandOption: false,
     })

--- a/core/src/cli.js
+++ b/core/src/cli.js
@@ -27,6 +27,12 @@ if (process.env.NO_CLI !== 'true') {
       type: 'boolean',
       demandOption: false,
     })
+    .option('c', {
+      alias: 'cors',
+      describe: 'CORS white list URLs',
+      type: 'string',
+      demandOption: false,
+    })
     .option('V', {
       alias: 'verbose',
       describe: 'Enable verbose logging',

--- a/core/src/config/index.js
+++ b/core/src/config/index.js
@@ -45,6 +45,10 @@ if (argv.database) {
   env.DB = argv.database;
 }
 
+if (argv.cors) {
+  env.CORS_ORIGIN_WHITELIST = argv.cors;
+}
+
 if (argv['rate-limit-enabled']) {
   env.RATE_LIMIT_ENABLED = argv['rate-limit-enabled'];
 }
@@ -71,7 +75,7 @@ module.exports = {
     filename: argv.database || envVars.DB || ':memory:',
   },
   cors: {
-    origin: envVars.CORS_ORIGIN_WHITELIST.split(','),
+    origin: argv.cors || envVars.CORS_ORIGIN_WHITELIST.split(','),
   },
   rateLimit: {
     enabled: argv['rate-limit-enabled'] || envVars.RATE_LIMIT_ENABLED,

--- a/core/src/config/index.js
+++ b/core/src/config/index.js
@@ -75,7 +75,7 @@ module.exports = {
     filename: argv.database || envVars.DB || ':memory:',
   },
   cors: {
-    origin: argv.cors || envVars.CORS_ORIGIN_WHITELIST.split(','),
+    origin: argv.cors.split(',') || envVars.CORS_ORIGIN_WHITELIST.split(','),
   },
   rateLimit: {
     enabled: argv['rate-limit-enabled'] || envVars.RATE_LIMIT_ENABLED,


### PR DESCRIPTION
### Issue

- When running Soul in development mode, all environment variables can be passed as a config in the .env file. However, when running the Soul CLI, only a few variables such as port, database, rate-limit, and extensions can be passed. As a result, when trying to access Soul from other applications, a CORS error occurs.

### Modification

- To address this issue, I have modified the /core/src/cli.js and /core/src/config/index.js files to allow passing CORS URLs using the -c command.

- Now, users can add the necessary CORS URLs like this:

  ```
    soul -d foobar.db -p 8000 -c http://localhost5173 -r true
  ```

- With this modification, users can avoid the CORS error when accessing Soul from other applications.
