### PR TITLE
Fix cors origin error in the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Install Soul CLI with npm
 ## Usage
 
 Soul is command line tool, after installing it,
-Run `soul -d sqlite.db -p 8000 -c "*"` and it'll start a REST API on [http://localhost:8000](http://localhost:8000) and a Websocket server on [ws://localhost:8000](ws://localhost:8000).
+Run `soul -d sqlite.db -p 8000` and it'll start a REST API on [http://localhost:8000](http://localhost:8000) and a Websocket server on [ws://localhost:8000](ws://localhost:8000).
 
 ```bash
 Usage: soul [options]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Install Soul CLI with npm
 ## Usage
 
 Soul is command line tool, after installing it,
-Run `soul -d sqlite.db -p 8000` and it'll start a REST API on [http://localhost:8000](http://localhost:8000) and a Websocket server on [ws://localhost:8000](ws://localhost:8000).
+Run `soul -d sqlite.db -p 8000 -c "*"` and it'll start a REST API on [http://localhost:8000](http://localhost:8000) and a Websocket server on [ws://localhost:8000](ws://localhost:8000).
 
 ```bash
 Usage: soul [options]

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "soul-cli",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "soul-cli",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^8.1.0",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soul-cli",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "A SQLite REST and Realtime server",
   "main": "src/server.js",
   "bin": {

--- a/core/src/config/index.js
+++ b/core/src/config/index.js
@@ -75,7 +75,8 @@ module.exports = {
     filename: argv.database || envVars.DB || ':memory:',
   },
   cors: {
-    origin: argv.cors.split(',') || envVars.CORS_ORIGIN_WHITELIST.split(','),
+    origin: argv.cors?.split(',') ||
+      envVars.CORS_ORIGIN_WHITELIST?.split(',') || ['*'],
   },
   rateLimit: {
     enabled: argv['rate-limit-enabled'] || envVars.RATE_LIMIT_ENABLED,

--- a/core/src/index.js
+++ b/core/src/index.js
@@ -28,15 +28,19 @@ app.use(bodyParser.json());
 db.pragma('journal_mode = WAL');
 
 // Enable CORS
-const corsOrigin = config.cors.origin;
+let corsOrigin = config.cors.origin;
+
+if (corsOrigin.includes('*')) {
+  corsOrigin = '*';
+}
+
 const corsOptions = {
-  origin: corsOrigin[0] === '*' ? '*' : corsOrigin,
+  origin: corsOrigin,
 };
 
 app.use(cors(corsOptions));
 
 // Log requests
-
 if (config.verbose !== null) {
   app.use(
     expressWinston.logger({

--- a/core/src/index.js
+++ b/core/src/index.js
@@ -28,9 +28,11 @@ app.use(bodyParser.json());
 db.pragma('journal_mode = WAL');
 
 // Enable CORS
+const corsOrigin = config.cors.origin;
 const corsOptions = {
-  origin: config.cors.origin,
+  origin: corsOrigin[0] === '*' ? '*' : corsOrigin,
 };
+
 app.use(cors(corsOptions));
 
 // Log requests


### PR DESCRIPTION
## Modifications 

1. Added a validation in `/config/index.js` to fix a bug introduced in the previous pull request. The validation checks if `argv.cors` is falsy and ensures that the cors origin whitelist is set correctly based on the command line argument `-c` or the environment variable `CORS_ORIGIN_WHITELIST` only if they are defined:
    ```js
       cors: {
           origin: argv.cors?.split(',') ||
           envVars.CORS_ORIGIN_WHITELIST?.split(',') || ['*'],
        },
     ```

2. Modified the code in `src/index.js` to fix the issue with CORS not allowing access from all origins when the user passes `*` from the CLI:
     ```js
       const corsOrigin = config.cors.origin
       const corsOptions = {
           origin: corsOrigin[0] === '*' ? '*' : corsOrigin
        };
       app.use(cors(corsOptions))
      ```