### PR TITLE
Add a function to put pks in quotes + Modify sql query for get,update…

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "soul-cli",
-  "version": "0.3.0",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "soul-cli",
-      "version": "0.3.0",
+      "version": "0.3.5",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^8.1.0",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soul-cli",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "A SQLite REST and Realtime server",
   "main": "src/server.js",
   "bin": {

--- a/core/src/controllers/rows.js
+++ b/core/src/controllers/rows.js
@@ -1,16 +1,22 @@
 const db = require('../db/index');
 
+const quotePrimaryKeys = (pks) => {
+  const primaryKeys = pks.split(',');
+  const quotedPks = primaryKeys.map((id) => `'${id}'`).join(',');
+  return quotedPks;
+};
+
 // Return paginated rows of a table
 const listTableRows = async (req, res) => {
-  /* 	
+  /*
     #swagger.tags = ['Rows']
-    #swagger.summary = 'List Rows' 
+    #swagger.summary = 'List Rows'
     #swagger.description = 'Endpoint to list rows of a table.'
-    #swagger.parameters['name'] = { 
+    #swagger.parameters['name'] = {
       description: 'Table name.',
       in: 'path',
     }
-    #swagger.parameters['_page'] = { 
+    #swagger.parameters['_page'] = {
       description: 'Page number.' ,
       in: 'query',
       type: 'number',
@@ -479,7 +485,9 @@ const getRowInTableByPK = async (req, res) => {
     });
   }
 
-  const query = `SELECT ${schemaString} FROM ${tableName} ${extendString} WHERE ${tableName}.${lookupField} in (${pks})`;
+  const query = `SELECT ${schemaString} FROM ${tableName} ${extendString} WHERE ${tableName}.${lookupField} in (${quotePrimaryKeys(
+    pks
+  )})`;
 
   try {
     let data = db.prepare(query).all();
@@ -534,7 +542,7 @@ const updateRowInTableByPK = async (req, res, next) => {
     }
 
     #swagger.parameters['body'] = {
-      in: 'body', 
+      in: 'body',
       required: true,
       type: 'object',
       schema: { $ref: "#/definitions/UpdateRowRequestBody" }
@@ -587,7 +595,10 @@ const updateRowInTableByPK = async (req, res, next) => {
     });
   }
 
-  const query = `UPDATE ${tableName} SET ${fieldsString} WHERE ${lookupField} in (${pks})`;
+  const query = `UPDATE ${tableName} SET ${fieldsString} WHERE ${lookupField} in (${quotePrimaryKeys(
+    pks
+  )})`;
+
   try {
     const data = db.prepare(query).run();
 
@@ -657,7 +668,9 @@ const deleteRowInTableByPK = async (req, res, next) => {
     }
   }
 
-  const query = `DELETE FROM ${tableName} WHERE ${lookupField} in (${pks})`;
+  const query = `DELETE FROM ${tableName} WHERE ${lookupField} in (${quotePrimaryKeys(
+    pks
+  )})`;
 
   try {
     const data = db.prepare(query).run();


### PR DESCRIPTION
# 1. Reason for PR

* When sending `GET`, `PUT`, and `DELETE` requests to the `api/tables/rows/:pks` API, the current code works fine for primary keys that are integers, but fails for primary keys that are string values. This is because the SQL query requires the primary keys to be passed in quotes, as shown in the following example query:

```sql
  SELECT * FROM Countries WHERE Album.id in ("'usa', 'france'")
```

* However, the current code block is generating an SQL query that is not in the correct format, such as the following example:

```sql
  SELECT * FROM Countries WHERE Album.id in ("usa, france")
```


# 2. Modifications

* This PR adds a function to the `/soul/core/src/controllers/rows.js` file that adds quotes for primary keys. It also modifies the SQL query in the `getRowInTableByPK`, `updateRowInTableByPK`, and `deleteRowInTableByPK` functions to use the new function for string types.

# 3. Changes Made

1. Added the `quotePrimaryKeys` function to add quotes for primary keys.
2. Modified the SQL queries in the `getRowInTableByPK`, `updateRowInTableByPK`, and `deleteRowInTableByPK` functions to use `quotePrimaryKeys` function 

These changes ensure that the API works correctly for primary keys of both integer and string types.