### PR TITLE
Modify SQL query used for filtering

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "soul-cli",
-  "version": "0.3.0",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "soul-cli",
-      "version": "0.3.0",
+      "version": "0.3.5",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^8.1.0",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soul-cli",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "A SQLite REST and Realtime server",
   "main": "src/server.js",
   "bin": {

--- a/core/src/controllers/rows.js
+++ b/core/src/controllers/rows.js
@@ -2,15 +2,15 @@ const db = require('../db/index');
 
 // Return paginated rows of a table
 const listTableRows = async (req, res) => {
-  /* 	
+  /*
     #swagger.tags = ['Rows']
-    #swagger.summary = 'List Rows' 
+    #swagger.summary = 'List Rows'
     #swagger.description = 'Endpoint to list rows of a table.'
-    #swagger.parameters['name'] = { 
+    #swagger.parameters['name'] = {
       description: 'Table name.',
       in: 'path',
     }
-    #swagger.parameters['_page'] = { 
+    #swagger.parameters['_page'] = {
       description: 'Page number.' ,
       in: 'query',
       type: 'number',
@@ -68,7 +68,7 @@ const listTableRows = async (req, res) => {
   if (_filters !== '') {
     whereString += ' WHERE ';
     whereString += filters
-      .map((filter) => `${tableName}.${filter.field} LIKE '%${filter.value}%'`)
+      .map((filter) => `${tableName}.${filter.field} = '${filter.value}'`)
       .join(' AND ');
   }
 
@@ -534,7 +534,7 @@ const updateRowInTableByPK = async (req, res, next) => {
     }
 
     #swagger.parameters['body'] = {
-      in: 'body', 
+      in: 'body',
       required: true,
       type: 'object',
       schema: { $ref: "#/definitions/UpdateRowRequestBody" }


### PR DESCRIPTION
# 1. Purpose of the PR
* Currently, when a GET request is sent to the `/api/tables/albums/rows?_filters=ArtistId:1` API, I expect to receive only the Albums where the `ArtistId` is equal to 1. However, the response is returning additional album fields that do not have an `ArtistId` of 1. The reason for this issue is due to an incorrect SQL query used in the `soul/core/src/controllers/rows.js` file:
    ```sql
      SELECT * FROM Albums WHERE albums.ArtistId LIKE %2%
    ```

* This query is not correct as it retrieves Albums with ArtistId values that include the digit 1, resulting in random albums being pulled from the database.

# 2. Changes Made
* This PR modifies the SQL query to retrieve only the exact albums based on the provided `ArtistId`. The query has been updated to:
   ```sql
     SELECT * FROM Albums WHERE albums.ArtistId = 2
   ```

* These changes ensure that the response only includes Albums with the provided ArtistId, resolving the issue with incorrect album fields being returned.