### PR TITLE
Expose SQLite views via API

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "soul-cli",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "soul-cli",
-      "version": "0.3.5",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^8.1.0",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soul-cli",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "description": "A SQLite REST and Realtime server",
   "main": "src/server.js",
   "bin": {

--- a/core/src/controllers/tables.js
+++ b/core/src/controllers/tables.js
@@ -162,9 +162,7 @@ const listTables = async (req, res) => {
   */
   const { _search, _ordering } = req.query;
 
-  let query = `SELECT name FROM sqlite_master WHERE type = 'table'
-     UNION
-     SELECT name FROM sqlite_master WHERE type = 'view'`;
+  let query = `SELECT name FROM sqlite_master WHERE type IN ('table', 'view')`;
 
   // if search is provided, search the tables
   // e.g. ?_search=users

--- a/core/src/controllers/tables.js
+++ b/core/src/controllers/tables.js
@@ -69,7 +69,7 @@ const createTable = async (req, res) => {
   // add id if primary key is not defined
   if (!schema.find((field) => field.primaryKey)) {
     schemaString = `
-        id INTEGER PRIMARY KEY AUTOINCREMENT, 
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
         ${schemaString}
       `;
   }
@@ -92,7 +92,7 @@ const createTable = async (req, res) => {
   let indicesString = indices
     .map((field) => {
       return `
-      CREATE INDEX ${tableName}_${field}_index 
+      CREATE INDEX ${tableName}_${field}_index
       ON ${tableName} (${field})
     `;
     })
@@ -162,7 +162,9 @@ const listTables = async (req, res) => {
   */
   const { _search, _ordering } = req.query;
 
-  let query = `SELECT name FROM sqlite_master WHERE type = 'table'`;
+  let query = `SELECT name FROM sqlite_master WHERE type = 'table'
+     UNION
+     SELECT name FROM sqlite_master WHERE type = 'view'`;
 
   // if search is provided, search the tables
   // e.g. ?_search=users
@@ -237,7 +239,7 @@ const deleteTable = async (req, res) => {
       type: 'string',
       description: 'Name of the table'
     }
-    
+
   */
   const { name: tableName } = req.params;
   const query = `DROP TABLE ${tableName}`;


### PR DESCRIPTION
# Purpose of the PR
* This pull request aims to add support for SQL views in addition to tables in the Soul app. Currently, the app only retrieves SQL tables from the database, but it would be useful to also expose SQL views.

# Changes Made
* The SQL query in the `core/src/controllers/tables.js` file has been modified to include SQL views in the results alongside tables. The new query is as follows:

    ```sql
        SELECT name FROM sqlite_master WHERE type IN ('table', 'view')
    ```
* With this change, the app will now retrieve both tables and views from the database when a request is sent to the `/api/tables` API.