### PR TITLE
Add support for filter operators

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "soul-cli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "soul-cli",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^8.1.0",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soul-cli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A SQLite REST and Realtime server",
   "main": "src/server.js",
   "bin": {

--- a/core/src/controllers/rows.js
+++ b/core/src/controllers/rows.js
@@ -73,16 +73,31 @@ const listTableRows = async (req, res) => {
   // filtering is case insensitive
   // e.g. ?_filters=name:John,age:20
   // will filter by name like '%John%' and age like '%20%'
+  let filters = [];
+  try {
+    filters = _filters.split(',').map((filter) => {
+      let [key, value] = filter.split(':');
 
-  const filters = _filters.split(',').map((filter) => {
-    let [key, value] = filter.split(':');
+      let field = key.split('__')[0];
+      let fieldOperator = key.split('__')[1];
 
-    let field = key.split('__')[0];
-    let fieldOperator = key.split('__')[1];
-    let operator = operators[fieldOperator ? fieldOperator : 'eq'];
+      if (!fieldOperator) {
+        fieldOperator = 'eq';
+      } else if (!operators[fieldOperator]) {
+        throw new Error(
+          `Invalid field operator "${fieldOperator}" for field "${field}". You can only use the following operators after the "${field}" field: __lt, __gt, __lte, __gte, __eq, __neq.`
+        );
+      }
 
-    return { field, operator, value };
-  });
+      let operator = operators[fieldOperator];
+      return { field, operator, value };
+    });
+  } catch (error) {
+    return res.status(400).json({
+      message: error.message,
+      error: error,
+    });
+  }
 
   let whereString = '';
   if (_filters !== '') {

--- a/core/src/controllers/rows.js
+++ b/core/src/controllers/rows.js
@@ -6,6 +6,15 @@ const quotePrimaryKeys = (pks) => {
   return quotedPks;
 };
 
+const operators = {
+  eq: '=',
+  lt: '<',
+  gt: '>',
+  lte: '<=',
+  gte: '>=',
+  neq: '!=',
+};
+
 // Return paginated rows of a table
 const listTableRows = async (req, res) => {
   /*
@@ -66,15 +75,23 @@ const listTableRows = async (req, res) => {
   // will filter by name like '%John%' and age like '%20%'
 
   const filters = _filters.split(',').map((filter) => {
-    const [field, value] = filter.split(':');
-    return { field, value };
+    let [key, value] = filter.split(':');
+
+    let field = key.split('__')[0];
+    let fieldOperator = key.split('__')[1];
+    let operator = operators[fieldOperator ? fieldOperator : 'eq'];
+
+    return { field, operator, value };
   });
 
   let whereString = '';
   if (_filters !== '') {
     whereString += ' WHERE ';
     whereString += filters
-      .map((filter) => `${tableName}.${filter.field} = '${filter.value}'`)
+      .map(
+        (filter) =>
+          `${tableName}.${filter.field} ${filter.operator} '${filter.value}'`
+      )
       .join(' AND ');
   }
 

--- a/docs/api/rows-examples.md
+++ b/docs/api/rows-examples.md
@@ -36,6 +36,7 @@ Response
 - `_schema` e.g. `?_schema=Title,ArtistId`, to get only the Title and ArtistId columns.
 - `_extend` e.g. `?_extend=ArtistId`, to get the Artist object related to the Album.
 - `_filters` e.g. `?_filters=ArtistId:1,Title:Rock`, to get only the rows where the ArtistId is 1 and the Title is Rock.
+  NOTE: If you want to use comparison operators in the filter, you can use these operators after the field: `__eq, __neq, __lt, __gt, __lte, __gte` . For example, you can use `/invoices/rows?_filters=InvoiceId__neq:1,Total__gte:5`
 
 Example with query params
 
@@ -115,11 +116,11 @@ Response
 
 ```json
 {
-	"data": {
-		"AlbumId": 1,
-		"Title": "For Those About To Rock We Salute You",
-		"ArtistId": 1
-	}
+  "data": {
+    "AlbumId": 1,
+    "Title": "For Those About To Rock We Salute You",
+    "ArtistId": 1
+  }
 }
 ```
 
@@ -143,16 +144,15 @@ Response
 
 ```json
 {
-	"data": {
-		"Title": "Facelift",
-		"ArtistId_data": {
-			"ArtistId": 5,
-			"Name": "Alice In Chains"
-		}
-	}
+  "data": {
+    "Title": "Facelift",
+    "ArtistId_data": {
+      "ArtistId": 5,
+      "Name": "Alice In Chains"
+    }
+  }
 }
 ```
-
 
 ### 4. Update Row(s) by ID
 
@@ -173,7 +173,7 @@ Response
 
 ```json
 {
-	"message": "Row updated"
+  "message": "Row updated"
 }
 ```
 
@@ -195,7 +195,6 @@ Response
 }
 ```
 
-
 ### 5. Delete Row(s) by ID
 
 To delete a row call `/tables/<table-name>/rows/<lookup-values>/` endpoint with `DELETE` method.
@@ -209,18 +208,17 @@ Response
 
 ```json
 {
-	"message": "Row deleted",
-	"data": {
-		"changes": 3290,
-		"lastInsertRowid": 0
-	}
+  "message": "Row deleted",
+  "data": {
+    "changes": 3290,
+    "lastInsertRowid": 0
+  }
 }
 ```
 
 #### Path Params
 
 - `lookup-values` e.g. `1`, to delete the row with the AlbumId 1. or comma-separated values e.g. `1,2`, to delete the row with the AlbumId 1 and ArtistId 2. (Bulk Delete)
-
 
 #### Query Params
 


### PR DESCRIPTION
Fixes #105 

# Purpose of PR

The purpose of this PR is to enhance the filtering feature of `Soul`. Currently, the `_filters` field is used for basic filtering, but it does not allow users to filter items by comparing them or by using comparison operators.

# Modifications

To address this limitation, I have made modifications to the `rows.js` file in the `core/src/controllers` directory. With these changes, users can now filter items using comparison operators such as `__lte`, `__gte`, `__lt`, `__gt`, `__eq`, and `__neq`. With this improved filtering functionality, users can more effectively search and analyze data in the Soul application.