### PR TITLE
Modify error handling for extended search

### DIFF
--- a/core/src/controllers/rows.js
+++ b/core/src/controllers/rows.js
@@ -157,7 +157,9 @@ const listTableRows = async (req, res) => {
   //   }
   // }
 
+  let foreignKeyError = { error: '', message: '' };
   let extendString = '';
+
   if (_extend) {
     const extendFields = _extend.split(',');
     extendFields.forEach((extendedField) => {
@@ -168,7 +170,9 @@ const listTableRows = async (req, res) => {
           .find((fk) => fk.from === extendedField);
 
         if (!foreignKey) {
-          throw new Error('Foreign key not found');
+          throw new Error(
+            `Foreign key not found for extended field '${extendedField}'`
+          );
         }
 
         const { table: joinedTableName } = foreignKey;
@@ -198,12 +202,17 @@ const listTableRows = async (req, res) => {
 
         schemaString += extendFieldsString;
       } catch (error) {
-        return res.status(400).json({
-          message: error.message,
-          error: error,
-        });
+        foreignKeyError.error = error;
+        foreignKeyError.message = error.message;
       }
     });
+
+    if (foreignKeyError.error) {
+      return res.status(400).json({
+        message: foreignKeyError.message,
+        error: foreignKeyError.error,
+      });
+    }
   }
 
   // get paginated rows


### PR DESCRIPTION
# Purpose of the PR
* When a request is sent to the `/api/tables/invoices/rows?_extend=CustomerId` API endpoint, Soul returns data from both the invoices and customer tables by extending the request using the `CustomerId` field. However, if an invalid foreign key is used in the `_extend parameter, such as `customerId` or `Total`, Soul returns an error message stating `"Foreign key not found."` Currently, if an invalid key is passed, Soul crashes and needs to be manually restarted.

# Reason for the error
* The reason for the error is that the `listTableRows` function in the `core/src/controllers/rows.js` file sends the `res.send(400)` signal to the client multiple times.

# Modification
* I have modified the error handling so that HTTP responses can't be sent to the client multiple times.