### PR TITLE
filtered values for insertion that are not null

### DIFF
--- a/core/src/controllers/rows.js
+++ b/core/src/controllers/rows.js
@@ -336,7 +336,12 @@ const insertRowInTable = async (req, res, next) => {
   */
 
   const { name: tableName } = req.params;
-  const { fields } = req.body;
+  const { fields:queryFields } = req.body;
+
+  const fields = Object.fromEntries(
+    Object.entries(queryFields).filter(([_, value]) => value !== null)
+  );
+
   const fieldsString = Object.keys(fields).join(', ');
 
   // wrap text values in quotes


### PR DESCRIPTION
fixes #126 

Removed the fields from `req.body.fields` that are `null` so no trailing commas are generated for null values.

This fix has been sponsored by @IanMayo 