### PR TITLE
Fix bug in comparison operators 

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "soul-cli",
-  "version": "0.5.2",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "soul-cli",
-      "version": "0.5.2",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^8.1.0",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soul-cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A SQLite REST and Realtime server",
   "main": "src/server.js",
   "bin": {

--- a/core/src/controllers/rows.js
+++ b/core/src/controllers/rows.js
@@ -83,7 +83,14 @@ const listTableRows = async (req, res) => {
   const re = /,(?![^\[]*?\])/;
   try {
     filters = _filters.split(re).map((filter) => {
-      let [key, value] = filter.split(':');
+      //NOTE: When using the _filter parameter, the values are split using the ":" sign, like this (_filters=Total__eq:1). However, if the user sends a date value, such as (_filters=InvoiceDate__eq:2010-01-08 00:00:00), there will be additional colon (":") signs present.
+      let [key, ...value] = filter.split(':');
+      if (value.length === 1) {
+        value = value[0];
+      } else {
+        value = value.map((element) => element).join(':');
+      }
+
       let field = key.split('__')[0];
       let fieldOperator = key.split('__')[1];
 
@@ -108,8 +115,6 @@ const listTableRows = async (req, res) => {
       error: error
     });
   }
-
-  //console.log('Filters ', filters);
 
   let whereString = '';
   const whereStringValues = [];

--- a/core/src/controllers/rows.js
+++ b/core/src/controllers/rows.js
@@ -15,7 +15,7 @@ const operators = {
   gte: '>=',
   neq: '!=',
   null: 'IS NULL',
-  notnull: 'IS NOT NULL',
+  notnull: 'IS NOT NULL'
 };
 
 // Return paginated rows of a table
@@ -80,11 +80,10 @@ const listTableRows = async (req, res) => {
   let filters = [];
 
   // split the filters by comma(,) except when in an array
-  const re = /(\w+:?(\[.*?\]|\w+)?)/g;
+  const re = /,(?![^\[]*?\])/;
   try {
-    filters = _filters.match(re)?.map((filter) => {
+    filters = _filters.split(re).map((filter) => {
       let [key, value] = filter.split(':');
-
       let field = key.split('__')[0];
       let fieldOperator = key.split('__')[1];
 
@@ -109,6 +108,8 @@ const listTableRows = async (req, res) => {
       error: error
     });
   }
+
+  //console.log('Filters ', filters);
 
   let whereString = '';
   const whereStringValues = [];
@@ -285,7 +286,7 @@ const listTableRows = async (req, res) => {
       orderString,
       limit,
       page: limit * (page - 1),
-      whereStringValues,
+      whereStringValues
     });
 
     // parse json extended files
@@ -305,7 +306,7 @@ const listTableRows = async (req, res) => {
     const total = rowService.getCount({
       tableName,
       whereString,
-      whereStringValues,
+      whereStringValues
     });
 
     const next =
@@ -377,14 +378,14 @@ const insertRowInTable = async (req, res, next) => {
     */
     res.status(201).json({
       message: 'Row inserted',
-      data,
+      data
     });
     req.broadcast = {
       type: 'INSERT',
       data: {
         pk: data.lastInsertRowid,
-        ...fields,
-      },
+        ...fields
+      }
     };
     next();
   } catch (error) {
@@ -398,7 +399,7 @@ const insertRowInTable = async (req, res, next) => {
     */
     res.status(400).json({
       message: error.message,
-      error: error,
+      error: error
     });
   }
 };
@@ -459,7 +460,7 @@ const getRowInTableByPK = async (req, res) => {
     } catch (error) {
       return res.status(400).json({
         message: error.message,
-        error: error,
+        error: error
       });
     }
   }
@@ -551,7 +552,7 @@ const getRowInTableByPK = async (req, res) => {
       } catch (error) {
         return res.status(400).json({
           message: error.message,
-          error: error,
+          error: error
         });
       }
     });
@@ -563,7 +564,7 @@ const getRowInTableByPK = async (req, res) => {
       tableName,
       extendString,
       lookupField,
-      pks,
+      pks
     });
 
     // parse json extended files
@@ -582,17 +583,17 @@ const getRowInTableByPK = async (req, res) => {
     if (data.length === 0) {
       return res.status(404).json({
         message: 'Row not found',
-        error: 'not_found',
+        error: 'not_found'
       });
     } else {
       res.json({
-        data,
+        data
       });
     }
   } catch (error) {
     return res.status(400).json({
       message: error.message,
-      error: error,
+      error: error
     });
   }
 };
@@ -646,7 +647,7 @@ const updateRowInTableByPK = async (req, res, next) => {
     } catch (error) {
       return res.status(400).json({
         message: error.message,
-        error: error,
+        error: error
       });
     }
   }
@@ -665,7 +666,7 @@ const updateRowInTableByPK = async (req, res, next) => {
   if (fieldsString === '') {
     return res.status(400).json({
       message: 'No fields provided',
-      error: 'no_fields_provided',
+      error: 'no_fields_provided'
     });
   }
 
@@ -674,26 +675,26 @@ const updateRowInTableByPK = async (req, res, next) => {
       tableName,
       fieldsString,
       lookupField,
-      pks,
+      pks
     });
 
     res.json({
       message: 'Row updated',
-      data,
+      data
     });
     req.broadcast = {
       type: 'UPDATE',
       _lookup_field: lookupField,
       data: {
         pks: pks.split(','),
-        ...fields,
-      },
+        ...fields
+      }
     };
     next();
   } catch (error) {
     res.status(400).json({
       message: error.message,
-      error: error,
+      error: error
     });
   }
 };
@@ -738,7 +739,7 @@ const deleteRowInTableByPK = async (req, res, next) => {
     } catch (error) {
       return res.status(400).json({
         message: error.message,
-        error: error,
+        error: error
       });
     }
   }
@@ -748,26 +749,26 @@ const deleteRowInTableByPK = async (req, res, next) => {
 
     if (data.changes === 0) {
       res.status(404).json({
-        error: 'not_found',
+        error: 'not_found'
       });
     } else {
       res.json({
         message: 'Row deleted',
-        data,
+        data
       });
       req.broadcast = {
         type: 'DELETE',
         _lookup_field: lookupField,
         data: {
-          pks: pks.split(','),
-        },
+          pks: pks.split(',')
+        }
       };
       next();
     }
   } catch (error) {
     res.status(400).json({
       message: error.message,
-      error: error,
+      error: error
     });
   }
 };
@@ -777,5 +778,5 @@ module.exports = {
   insertRowInTable,
   getRowInTableByPK,
   updateRowInTableByPK,
-  deleteRowInTableByPK,
+  deleteRowInTableByPK
 };

--- a/core/src/controllers/rows.test.js
+++ b/core/src/controllers/rows.test.js
@@ -30,7 +30,7 @@ describe('Rows Endpoints', () => {
       _ordering: '-firstName',
       _schema: 'firstName,lastName',
       _limit: 8,
-      _page: 2,
+      _page: 2
     };
     const query = queryString(params);
     const res = await requestWithSupertest.get(
@@ -47,14 +47,14 @@ describe('Rows Endpoints', () => {
     expect(res.body.next).toEqual(
       `/tables/users/rows?${queryString({
         ...params,
-        _page: params._page + 1,
+        _page: params._page + 1
       }).toString()}`
     );
 
     expect(res.body.previous).toEqual(
       `/tables/users/rows?${queryString({
         ...params,
-        _page: params._page - 1,
+        _page: params._page - 1
       }).toString()}`
     );
   });
@@ -67,6 +67,18 @@ describe('Rows Endpoints', () => {
     expect(res.status).toEqual(200);
     expect(res.body.data[0].firstName).toBeNull();
     expect(res.body.data[0].lastName).not.toBeNull();
+  });
+
+  it('GET /tables/:name/rows: should filter items by createdAt date', async () => {
+    const res = await requestWithSupertest.get(
+      '/api/tables/users/rows?_filters=createdAt__gte:2009-01-01 00:00:00'
+    );
+
+    expect(res.status).toEqual(200);
+    expect(res.body.data[0]).toHaveProperty('id');
+    expect(res.body.data[0]).toHaveProperty('firstName');
+    expect(res.body.data[0]).toHaveProperty('lastName');
+    expect(res.body.data[0]).toHaveProperty('createdAt');
   });
 
   it('POST /tables/:name/rows should insert a new row and return the lastInsertRowid', async () => {
@@ -103,16 +115,14 @@ describe('Rows Endpoints', () => {
   });
 
   it('POST /tables/:name/rows should insert a new row if any of the value of the object being inserted is null', async () => {
-    const res = await requestWithSupertest
-      .post('/api/tables/users/rows')
-      .send({
-        fields: {
-          firstName: null,
-          lastName: 'Doe',
-          email: null,
-          username: 'Jane'
-        }
-      });
+    const res = await requestWithSupertest.post('/api/tables/users/rows').send({
+      fields: {
+        firstName: null,
+        lastName: 'Doe',
+        email: null,
+        username: 'Jane'
+      }
+    });
     expect(res.status).toEqual(201);
     expect(res.type).toEqual(expect.stringContaining('json'));
     expect(res.body).toHaveProperty('data');
@@ -137,5 +147,4 @@ describe('Rows Endpoints', () => {
     expect(res.body.data).toEqual(expect.any(Array));
     expect(res.body.data.length).toEqual(1);
   });
-
 });

--- a/core/src/tests/index.js
+++ b/core/src/tests/index.js
@@ -27,17 +27,17 @@ const dropTestDatabase = async (path = 'test.db') => {
 
 const createTestTable = (table = 'users') => {
   db.prepare(
-    `CREATE TABLE ${table} (id INTEGER PRIMARY KEY, firstName TEXT, lastName TEXT, email TEXT, username TEXT)`
+    `CREATE TABLE ${table} (id INTEGER PRIMARY KEY, firstName TEXT, lastName TEXT, email TEXT, username TEXT, createdAt TEXT)`
   ).run();
 };
 
 const insertIntoTestTable = (table = 'users') => {
   const statement = db.prepare(
-    `INSERT INTO ${table} (firstName, lastName) VALUES (?, ?)`
+    `INSERT INTO ${table} (firstName, lastName, createdAt) VALUES (?, ?, ?)`
   );
 
   for (const user of testNames) {
-    statement.run(user.firstName, user.lastName);
+    statement.run(user.firstName, user.lastName, user.createdAt);
   }
 };
 
@@ -45,5 +45,5 @@ module.exports = {
   dropTestTable,
   dropTestDatabase,
   createTestTable,
-  insertIntoTestTable,
+  insertIntoTestTable
 };

--- a/core/src/tests/testData.js
+++ b/core/src/tests/testData.js
@@ -1,30 +1,62 @@
 const testNames = [
-  { firstName: 'Emily', lastName: 'William' },
-  { firstName: 'Michael', lastName: 'Lee' },
-  { firstName: 'Sarah', lastName: 'Johnson' },
-  { firstName: 'David', lastName: 'Chen' },
-  { firstName: 'Olivia', lastName: 'William' },
-  { firstName: 'William', lastName: 'Kim' },
-  { firstName: 'Sophia', lastName: 'Singh' },
-  { firstName: 'James', lastName: 'Rodriguez' },
-  { firstName: 'Ava', lastName: 'Patel' },
-  { firstName: 'Benjamin', lastName: 'Garcia' },
-  { firstName: 'Isabella', lastName: 'Nguyen' },
-  { firstName: 'Ethan', lastName: 'Lee' },
-  { firstName: 'Mia', lastName: 'Wilson' },
-  { firstName: 'Alexander', lastName: 'William' },
-  { firstName: 'Charlotte', lastName: 'Hernandez' },
-  { firstName: 'Liam', lastName: 'Gonzalez' },
-  { firstName: 'Emma', lastName: 'Gomez' },
-  { firstName: 'Noah', lastName: 'Perez' },
-  { firstName: 'Avery', lastName: 'Ramirez' },
-  { firstName: 'Jacob', lastName: 'Turner' },
-  { firstName: 'Abigail', lastName: 'Williams' },
-  { firstName: 'Elijah', lastName: 'Hall' },
-  { firstName: 'Mila', lastName: 'Flores' },
-  { firstName: 'Evelyn', lastName: 'Morales' },
-  { firstName: 'Logan', lastName: 'Collins' },
-  { firstName: null, lastName: 'Flores' },
+  { firstName: 'Emily', lastName: 'William', createdAt: '2008-01-08 00:00:00' },
+  { firstName: 'Michael', lastName: 'Lee', createdAt: '2009-01-08 00:00:00' },
+  { firstName: 'Sarah', lastName: 'Johnson', createdAt: '2010-01-08 00:00:00' },
+  { firstName: 'David', lastName: 'Chen', createdAt: '2011-01-08 00:00:00' },
+  {
+    firstName: 'Olivia',
+    lastName: 'William',
+    createdAt: '2012-01-08 00:00:00'
+  },
+  { firstName: 'William', lastName: 'Kim', createdAt: '2013-01-08 00:00:00' },
+  { firstName: 'Sophia', lastName: 'Singh', createdAt: '2013-02-08 00:00:00' },
+  {
+    firstName: 'James',
+    lastName: 'Rodriguez',
+    createdAt: '2013-03-08 00:00:00'
+  },
+  { firstName: 'Ava', lastName: 'Patel', createdAt: '2013-01-04 00:00:00' },
+  {
+    firstName: 'Benjamin',
+    lastName: 'Garcia',
+    createdAt: '2015-01-08 00:00:00'
+  },
+  {
+    firstName: 'Isabella',
+    lastName: 'Nguyen',
+    createdAt: '2014-01-08 00:00:00'
+  },
+  { firstName: 'Ethan', lastName: 'Lee', createdAt: '2016-01-08 00:00:00' },
+  { firstName: 'Mia', lastName: 'Wilson', createdAt: '2017-01-08 00:00:00' },
+  {
+    firstName: 'Alexander',
+    lastName: 'William',
+    createdAt: '2018-01-08 00:00:00'
+  },
+  {
+    firstName: 'Charlotte',
+    lastName: 'Hernandez',
+    createdAt: '2019-01-08 00:00:00'
+  },
+  { firstName: 'Liam', lastName: 'Gonzalez', createdAt: '2020-01-08 00:00:00' },
+  { firstName: 'Emma', lastName: 'Gomez', createdAt: '2021-01-08 00:00:00' },
+  { firstName: 'Noah', lastName: 'Perez', createdAt: '2022-01-08 00:00:00' },
+  { firstName: 'Avery', lastName: 'Ramirez', createdAt: '2023-02-08 00:00:00' },
+  { firstName: 'Jacob', lastName: 'Turner', createdAt: '2023-03-08 00:00:00' },
+  {
+    firstName: 'Abigail',
+    lastName: 'Williams',
+    createdAt: '2023-02-10 00:00:00'
+  },
+  { firstName: 'Elijah', lastName: 'Hall', createdAt: '2023-04-02 00:00:00' },
+  { firstName: 'Mila', lastName: 'Flores', createdAt: '2023-05-13 00:00:00' },
+  {
+    firstName: 'Evelyn',
+    lastName: 'Morales',
+    createdAt: '2023-06-05 00:00:00'
+  },
+  { firstName: 'Logan', lastName: 'Collins', createdAt: '2023-06-07 00:00:00' },
+  { firstName: null, lastName: 'Flores', createdAt: '2023-06-09 00:00:00' }
 ];
 
 module.exports = { testNames };

--- a/core/src/tests/testData.js
+++ b/core/src/tests/testData.js
@@ -40,7 +40,7 @@ const testNames = [
   },
   { firstName: 'Liam', lastName: 'Gonzalez', createdAt: '2020-01-08 00:00:00' },
   { firstName: 'Emma', lastName: 'Gomez', createdAt: '2021-01-08 00:00:00' },
-  { firstName: 'Noah', lastName: 'Perez', createdAt: '2022-01-08 00:00:00' },
+  { firstName: 'Noah', lastName: 'Perez', createdAt: '2021-01-08 00:00:00' },
   { firstName: 'Avery', lastName: 'Ramirez', createdAt: '2023-02-08 00:00:00' },
   { firstName: 'Jacob', lastName: 'Turner', createdAt: '2023-03-08 00:00:00' },
   {


### PR DESCRIPTION
PR Sponsored By @IanMayo 

Fixes #135 

### Modifications 

The comparison operators __gte, __lte, __gt, and __lt were not working for string values with a hyphen. I have changed the regex syntax.