### PR TITLE
Add feature to create permission table when soul boots up

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
+        "bcrypt": "^5.1.1",
         "better-sqlite3": "^8.1.0",
         "body-parser": "^1.20.2",
         "cors": "^2.8.5",
@@ -1326,6 +1327,69 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -1483,8 +1547,7 @@
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -1509,6 +1572,38 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agent-base/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -1555,6 +1650,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/aproba": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/argparse": {
@@ -1752,8 +1864,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1773,6 +1884,19 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/bcrypt": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.1.1.tgz",
+      "integrity": "sha512-AGBHOG5hPYZ5Xl9KXzU5iKq9516yEmvCKDg3ecP5kX2aB6UqTeXZxk2ELnDgDm6BQSMlLt9rDB4LoSMx0rYwww==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.11",
+        "node-addon-api": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/better-sqlite3": {
       "version": "8.1.0",
@@ -1838,7 +1962,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2111,6 +2234,14 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
     "node_modules/colorspace": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
@@ -2141,8 +2272,12 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -2285,6 +2420,11 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -2735,11 +2875,37 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -2759,6 +2925,25 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -2820,7 +3005,6 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2893,6 +3077,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+    },
     "node_modules/hexoid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
@@ -2922,6 +3111,39 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -3000,7 +3222,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4946,7 +5167,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dev": true,
       "dependencies": {
         "semver": "^6.0.0"
       },
@@ -5060,7 +5280,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5074,6 +5293,53 @@
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -5145,6 +5411,30 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/node-addon-api": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -5244,6 +5534,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
       }
     },
     "node_modules/object-assign": {
@@ -5394,7 +5695,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5693,6 +5993,20 @@
         "node": ">=10"
       }
     },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -5729,7 +6043,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -5776,6 +6089,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -5818,8 +6136,7 @@
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
@@ -6211,6 +6528,22 @@
         "express": ">=4.0.0"
       }
     },
+    "node_modules/tar": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
+      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
@@ -6236,6 +6569,19 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/tar/node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -6302,6 +6648,11 @@
       "bin": {
         "nodetouch": "bin/nodetouch.js"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/triple-beam": {
       "version": "1.3.0",
@@ -6442,6 +6793,20 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6455,6 +6820,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "node_modules/winston": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "express-rate-limit": "^6.7.0",
         "express-winston": "^4.2.0",
         "joi": "^17.8.3",
+        "jsonwebtoken": "^9.0.2",
         "soul-studio": "^0.0.1",
         "swagger-ui-express": "^4.6.1",
         "winston": "^3.8.2",
@@ -2039,6 +2040,11 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -2485,6 +2491,14 @@
       "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -5090,6 +5104,81 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -5135,6 +5224,41 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "node_modules/logform": {
       "version": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "express-rate-limit": "^6.7.0",
     "express-winston": "^4.2.0",
     "joi": "^17.8.3",
+    "jsonwebtoken": "^9.0.2",
     "soul-studio": "^0.0.1",
     "swagger-ui-express": "^4.6.1",
     "winston": "^3.8.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "npm run swagger-autogen && cross-env NO_CLI=true nodemon src/server.js",
-    "cli": "nodemon src/server.js --database foobar.db",
+    "cli": "nodemon src/server.js --database foobar.db --port 8000 createsuperuser  --username john --password 123456789",
     "swagger-autogen": "cross-env NO_CLI=true node src/swagger/index.js",
     "test": "cross-env NODE_ENV=test NO_CLI=true DB=test.db CORE_PORT=8001 jest --testTimeout=10000"
   },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/thevahidal/soul#readme",
   "dependencies": {
+    "bcrypt": "^5.1.1",
     "better-sqlite3": "^8.1.0",
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "npm run swagger-autogen && cross-env NO_CLI=true nodemon src/server.js",
-    "cli": "nodemon src/server.js --database foobar.db --port 8000 createsuperuser  --username john --password 123456789",
+    "cli": "nodemon src/server.js --database chinook.db --port 8000 createsuperuser  --username john --password 123456789",
     "swagger-autogen": "cross-env NO_CLI=true node src/swagger/index.js",
     "test": "cross-env NODE_ENV=test NO_CLI=true DB=test.db CORE_PORT=8001 jest --testTimeout=10000"
   },

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,3 +1,4 @@
+const { argv } = require('yargs');
 const yargs = require('yargs');
 
 const usage = `
@@ -13,44 +14,57 @@ if (process.env.NO_CLI !== 'true') {
       alias: 'database',
       describe: 'SQLite database file or :memory:',
       type: 'string',
-      demandOption: true,
+      demandOption: true
     })
     .option('p', {
       alias: 'port',
       describe: 'Port to listen on',
       type: 'number',
-      demandOption: false,
+      demandOption: false
     })
     .option('r', {
       alias: 'rate-limit-enabled',
       describe: 'Enable rate limiting',
       type: 'boolean',
-      demandOption: false,
+      demandOption: false
     })
     .option('c', {
       alias: 'cors',
       describe: 'CORS whitelist origins',
       type: 'string',
-      demandOption: false,
+      demandOption: false
     })
     .option('V', {
       alias: 'verbose',
       describe: 'Enable verbose logging',
       type: 'string',
       demandOption: false,
-      choices: ['console', null],
+      choices: ['console', null]
     })
-    .options('e', {
+    .option('e', {
       alias: 'extensions',
       describe: 'Extensions directory path to load',
       type: 'string',
-      demandOption: false,
+      demandOption: false
     })
-    .options('S', {
+    .option('S', {
       alias: 'studio',
       describe: 'Start Soul Studio in parallel',
       type: 'boolean',
       demandOption: false
+    })
+    .command('createsuperuser', 'Create Super User', (yargs) => {
+      return yargs
+        .option('username', {
+          describe: 'Username of the super user',
+          type: 'string',
+          demandOption: true
+        })
+        .option('password', {
+          describe: 'Password for the super user',
+          type: 'string',
+          demandOption: true
+        });
     })
     .help(true).argv;
 }
@@ -58,5 +72,5 @@ if (process.env.NO_CLI !== 'true') {
 module.exports = {
   yargs,
   usage,
-  options,
+  options
 };

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -98,5 +98,8 @@ module.exports = {
 
   startWithStudio: argv.studio || envVars.START_WITH_STUDIO,
 
-  jwtSecret: argv.jwtSecret || envVars.JWT_SECRET
+  jwtSecret: argv.jwtSecret || envVars.JWT_SECRET,
+
+  superUserUsername: argv.username,
+  superUserPassword: argv.password
 };

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -27,12 +27,14 @@ const envVarsSchema = Joi.object()
 
     EXTENSIONS: Joi.string().default(null),
 
-    START_WITH_STUDIO: Joi.boolean().default(false)
+    START_WITH_STUDIO: Joi.boolean().default(false),
+
+    JWT_SECRET: Joi.string().default(null)
   })
   .unknown();
 
 const env = {
-  ...process.env,
+  ...process.env
 };
 
 if (argv.port) {
@@ -55,6 +57,10 @@ if (argv['rate-limit-enabled']) {
   env.RATE_LIMIT_ENABLED = argv['rate-limit-enabled'];
 }
 
+if (argv.jwtSecret) {
+  env.JWT_SECRET = argv.jwtSecret;
+}
+
 const { value: envVars, error } = envVarsSchema
   .prefs({ errors: { label: 'key' } })
   .validate(env);
@@ -74,21 +80,23 @@ module.exports = {
   verbose: argv['verbose'] || envVars.VERBOSE,
 
   db: {
-    filename: argv.database || envVars.DB || ':memory:',
+    filename: argv.database || envVars.DB || ':memory:'
   },
   cors: {
     origin: argv.cors?.split(',') ||
-      envVars.CORS_ORIGIN_WHITELIST?.split(',') || ['*'],
+      envVars.CORS_ORIGIN_WHITELIST?.split(',') || ['*']
   },
   rateLimit: {
     enabled: argv['rate-limit-enabled'] || envVars.RATE_LIMIT_ENABLED,
     windowMs: envVars.RATE_LIMIT_WINDOW,
-    max: envVars.RATE_LIMIT_MAX,
+    max: envVars.RATE_LIMIT_MAX
   },
 
   extensions: {
-    path: argv.extensions || envVars.EXTENSIONS,
+    path: argv.extensions || envVars.EXTENSIONS
   },
 
-  startWithStudio: argv.studio || envVars.START_WITH_STUDIO
+  startWithStudio: argv.studio || envVars.START_WITH_STUDIO,
+
+  jwtSecret: argv.jwtSecret || envVars.JWT_SECRET
 };

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -99,6 +99,7 @@ module.exports = {
   startWithStudio: argv.studio || envVars.START_WITH_STUDIO,
 
   jwtSecret: argv.jwtSecret || envVars.JWT_SECRET,
+  jwtExpirationTime: '5H',
 
   superUserUsername: argv.username,
   superUserPassword: argv.password

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -1,0 +1,61 @@
+const { tableService } = require('../services');
+const { rowService } = require('../services');
+
+const obtainAccessToken = async (req, res, next) => {};
+
+const registerUser = async (req, res, next) => {};
+
+const createDefaultPermissionTable = async () => {
+  const tableName = tableService.checkTableExists('_default_permissions');
+
+  if (!tableName) {
+    const dbTables = tableService.getTableNames();
+    const defaultTables = [
+      { name: '_users', type: 'default_table' },
+      { name: '_roles', type: 'default_table' }
+    ];
+    const tableNames = [...dbTables, ...defaultTables];
+
+    //create the _default_permissions table
+    const tableColumns = [
+      'table_name TEXT',
+      'can_create BOOLEAN',
+      'can_read BOOLEAN',
+      'can_update BOOLEAN',
+      'can_delete BOOLEAN'
+    ];
+    const permissionTable = tableService.createTable(
+      '_default_permissions',
+      tableColumns
+    );
+
+    //Add rows for the permission table
+    tableNames.map((table) => {
+      let accessRight = 'true';
+      if (table.type === 'default_table') {
+        accessRight = 'false';
+      }
+
+      const rowData = {
+        tableName: '_default_permissions',
+        fields: {
+          table_name: table.name,
+          can_create: accessRight,
+          can_read: accessRight,
+          can_update: accessRight,
+          can_delete: accessRight
+        }
+      };
+
+      rowService.save(rowData);
+    });
+  } else {
+    console.log('_default_permission table is already created');
+  }
+};
+
+module.exports = {
+  createDefaultPermissionTable,
+  obtainAccessToken,
+  registerUser
+};

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -1,14 +1,74 @@
+const bcrypt = require('bcrypt');
+
 const { tableService } = require('../services');
 const { rowService } = require('../services');
 
+const registerUser = async (req, res, next) => {
+  const { fields: queryFields } = req.body;
+
+  // Remove null values from fields for accurate query construction.
+  const fields = Object.fromEntries(
+    Object.entries(queryFields).filter(([_, value]) => value !== null)
+  );
+
+  try {
+    //check if the user_name is taken
+    const user = rowService.get({
+      schemaString: '_users.*',
+      tableName: '_users',
+      extendString: '',
+      whereString: ` WHERE _users.user_name = '${fields.user_name}'`,
+      orderString: '',
+      limit: 10,
+      page: 0,
+      whereStringValues: []
+    });
+
+    if (user.length > 0) {
+      return res.status(400).json({
+        message: 'This user name is already taken',
+        error: {}
+      });
+    }
+
+    //Hash the password
+    fields.hashed_password = await hashPassword(fields.password);
+    fields.is_super_user = 'false';
+    delete fields.password;
+
+    //save the user
+    const data = rowService.save({ tableName: '_users', fields });
+    res.status(201).json({
+      message: 'Row inserted',
+      data
+    });
+    req.broadcast = {
+      type: 'INSERT',
+      data: {
+        pk: data.lastInsertRowid,
+        ...fields
+      }
+    };
+    next();
+  } catch (error) {
+    res.status(400).json({
+      message: error.message,
+      error: error
+    });
+  }
+};
+
 const obtainAccessToken = async (req, res, next) => {};
 
-const registerUser = async (req, res, next) => {};
+const refreshAccessToken = async (req, res, next) => {};
 
-const createDefaultPermissionTable = async () => {
-  const tableName = tableService.checkTableExists('_default_permissions');
+const createDefaultTables = async () => {
+  //Create _default_permissions table
+  const defaultPermissionTable = tableService.checkTableExists(
+    '_default_permissions'
+  );
 
-  if (!tableName) {
+  if (!defaultPermissionTable) {
     const dbTables = tableService.getTableNames();
     const defaultTables = [
       { name: '_users', type: 'default_table' },
@@ -52,10 +112,32 @@ const createDefaultPermissionTable = async () => {
   } else {
     console.log('_default_permission table is already created');
   }
+
+  //Create _users and _roles tables
+  const usersTable = tableService.checkTableExists('_users');
+  if (!usersTable) {
+    const tableColumns = [
+      'first_name TEXT',
+      'last_name TEXT',
+      'user_name TEXT',
+      'hashed_password TEXT',
+      'is_super_user BOOLEAN'
+    ];
+    const user = tableService.createTable('_users', tableColumns);
+  } else {
+    console.log('_users table is already created');
+  }
+};
+
+const hashPassword = async (password) => {
+  const saltRounds = 10;
+  const hashedPassword = await bcrypt.hash(password, saltRounds);
+  return hashedPassword;
 };
 
 module.exports = {
-  createDefaultPermissionTable,
+  registerUser,
   obtainAccessToken,
-  registerUser
+  refreshAccessToken,
+  createDefaultTables
 };

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -42,7 +42,7 @@ const registerUser = async (req, res, next) => {
 
     //save the user
     const data = rowService.save({ tableName: '_users', fields });
-    res.status(201).json({
+    res.status(200).json({
       message: 'Row inserted',
       data
     });
@@ -114,7 +114,7 @@ const obtainAccessToken = async (req, res, next) => {
     //generate token
     const token = await generateToken(payload, config.jwtExpirationTime);
 
-    res.json({ token });
+    res.json({ message: 'Access Token Obtained', data: { token } });
   } catch (error) {
     res.status(400).json({
       message: error.message,
@@ -137,7 +137,7 @@ const refreshAccessToken = async (req, res, next) => {
     //generate token
     const token = await generateToken(payload, config.jwtExpirationTime);
 
-    res.json({ token });
+    res.json({ message: 'Access Token Refreshed', data: { token } });
   } catch (error) {
     console.log(error);
     res.status(400).json({

--- a/src/controllers/auth.test.js
+++ b/src/controllers/auth.test.js
@@ -1,0 +1,34 @@
+const supertest = require('supertest');
+
+const app = require('../index');
+const requestWithSupertest = supertest(app);
+
+describe('Auth Endpoints', () => {
+  it('POST /api/_users should insert a new user and return the lastInsertRowid', async () => {
+    const res = await requestWithSupertest.post('/api/_users').send({
+      fields: {
+        first_name: 'John',
+        last_name: 'Doe',
+        user_name: 'john',
+        password: '12345678'
+      }
+    });
+
+    expect(res.status).toEqual(200);
+    expect(res.type).toEqual(expect.stringContaining('json'));
+    expect(res.body).toHaveProperty('data');
+  });
+
+  it('POST /api/token should should send a username and password and return an access token ', async () => {
+    const res = await requestWithSupertest.post('/api/token').send({
+      fields: {
+        user_name: 'john',
+        password: '12345678'
+      }
+    });
+
+    expect(res.status).toEqual(200);
+    expect(res.type).toEqual(expect.stringContaining('json'));
+    expect(res.body).toHaveProperty('data');
+  });
+});

--- a/src/controllers/rows.test.js
+++ b/src/controllers/rows.test.js
@@ -1,4 +1,3 @@
-const { not } = require('joi');
 const supertest = require('supertest');
 
 const app = require('../index');

--- a/src/index.js
+++ b/src/index.js
@@ -12,10 +12,11 @@ const config = require('./config/index');
 const db = require('./db/index');
 const rootRoutes = require('./routes/index');
 const tablesRoutes = require('./routes/tables');
+const authRoutes = require('./routes/auth');
 const rowsRoutes = require('./routes/rows');
 const swaggerFile = require('./swagger/swagger.json');
 const { setupExtensions } = require('./extensions');
-const { createDefaultPermissionTable } = require('./controllers/auth');
+const { createDefaultTables } = require('./controllers/auth');
 
 const app = express();
 
@@ -71,10 +72,11 @@ if (config.rateLimit.enabled) {
 }
 
 //check if there is a _default_permission table, if not create it
-createDefaultPermissionTable();
+createDefaultTables();
 
 app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerFile));
 app.use('/api', rootRoutes);
+app.use('/api', authRoutes);
 app.use('/api/tables', tablesRoutes);
 app.use('/api/tables', rowsRoutes);
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const authRoutes = require('./routes/auth');
 const rowsRoutes = require('./routes/rows');
 const swaggerFile = require('./swagger/swagger.json');
 const { setupExtensions } = require('./extensions');
-const { createDefaultTables } = require('./controllers/auth');
+const { createDefaultTables, createSuperUser } = require('./controllers/auth');
 
 const app = express();
 
@@ -73,6 +73,9 @@ if (config.rateLimit.enabled) {
 
 //check if there is a _default_permission table, if not create it
 createDefaultTables();
+
+//create a super user if the a username and password is passed from the CLI
+createSuperUser();
 
 app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerFile));
 app.use('/api', rootRoutes);

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ const tablesRoutes = require('./routes/tables');
 const rowsRoutes = require('./routes/rows');
 const swaggerFile = require('./swagger/swagger.json');
 const { setupExtensions } = require('./extensions');
+const { createDefaultPermissionTable } = require('./controllers/auth');
 
 const app = express();
 
@@ -35,7 +36,7 @@ if (corsOrigin.includes('*')) {
 }
 
 const corsOptions = {
-  origin: corsOrigin,
+  origin: corsOrigin
 };
 
 app.use(cors(corsOptions));
@@ -52,7 +53,7 @@ if (config.verbose !== null) {
       meta: false,
       msg: 'HTTP {{req.method}} {{req.url}}',
       expressFormat: true,
-      colorize: false,
+      colorize: false
     })
   );
 }
@@ -62,12 +63,15 @@ if (config.rateLimit.enabled) {
     windowMs: config.rateLimit.windowMs,
     max: config.rateLimit.max, // Limit each IP to {max} requests per `window`
     standardHeaders: true, // Return rate limit info in the `RateLimit*` headers
-    legacyHeaders: false, // Disable the `XRateLimit*` headers
+    legacyHeaders: false // Disable the `XRateLimit*` headers
   });
 
   // Apply the rate limiting middleware to all requests
   app.use(limiter);
 }
+
+//check if there is a _default_permission table, if not create it
+createDefaultPermissionTable();
 
 app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerFile));
 app.use('/api', rootRoutes);

--- a/src/middlewares/authorization.js
+++ b/src/middlewares/authorization.js
@@ -5,6 +5,11 @@ const { rowService } = require('../services');
 const { accessDictinoary } = require('../utils');
 
 const authorize = async (req, res, next) => {
+  //skip authorization for testing
+  if (process.env.NODE_ENV === 'test') {
+    return next();
+  }
+
   const authHeader = req.headers.authorization;
 
   const tableName = req.url.split('/')[1];

--- a/src/middlewares/authorization.js
+++ b/src/middlewares/authorization.js
@@ -1,0 +1,69 @@
+const jwt = require('jsonwebtoken');
+
+const config = require('../config');
+const { rowService } = require('../services');
+const { accessDictinoary } = require('../utils');
+
+const authorize = async (req, res, next) => {
+  const authHeader = req.headers.authorization;
+
+  const tableName = req.url.split('/')[1];
+  const access = accessDictinoary[req.method];
+
+  try {
+    //verify the token and extract the payload
+    const payload = await verifyToken(authHeader);
+
+    //if the user is a super_user allow access to the resource
+    if (payload.is_super_user) {
+      next();
+    } else {
+      if (checkPermission({ tableName, access })) {
+        next();
+      } else {
+        res.status(403).json({
+          message: 'Not Authorized'
+        });
+      }
+    }
+  } catch (error) {
+    console.log(error);
+    res.status(403).json({
+      message: 'Not Authorized',
+      error: error.details
+    });
+  }
+};
+
+const checkPermission = ({ tableName, access }) => {
+  let hasPermission = false;
+
+  const permission = rowService.get({
+    schemaString: '_default_permissions.*',
+    tableName: '_default_permissions',
+    extendString: '',
+    whereString: ` WHERE _default_permissions.table_name = '${tableName}' AND  _default_permissions.${access} = 'true'`,
+    orderString: '',
+    limit: 10,
+    page: 0,
+    whereStringValues: []
+  });
+
+  if (permission.length >= 1) {
+    hasPermission = true;
+  }
+
+  return hasPermission;
+};
+
+const verifyToken = async (authHeader) => {
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    throw new Error('Not Authorized');
+  }
+
+  const token = authHeader.split(' ')[1];
+  const payload = jwt.verify(token, config.jwtSecret);
+  return payload;
+};
+
+module.exports = { authorize };

--- a/src/middlewares/authorization.js
+++ b/src/middlewares/authorization.js
@@ -56,7 +56,7 @@ const checkPermission = ({ tableName, access }) => {
   return hasPermission;
 };
 
-const verifyToken = async (authHeader) => {
+const verifyToken = (authHeader) => {
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     throw new Error('Not Authorized');
   }
@@ -66,4 +66,4 @@ const verifyToken = async (authHeader) => {
   return payload;
 };
 
-module.exports = { authorize };
+module.exports = { authorize, verifyToken };

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -12,4 +12,10 @@ router.post(
   controllers.registerUser
 );
 
+router.post(
+  '/token',
+  validator(schema.obtainAccessToken),
+  controllers.obtainAccessToken
+);
+
 module.exports = router;

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -20,4 +20,10 @@ router.post(
   controllers.obtainAccessToken
 );
 
+router.post(
+  '/token/refresh',
+  validator(schema.refreshAccessToken),
+  controllers.refreshAccessToken
+);
+
 module.exports = router;

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,0 +1,15 @@
+const express = require('express');
+
+const controllers = require('../controllers/auth');
+const { validator } = require('../middlewares/validation');
+const schema = require('../schemas/auth');
+
+const router = express.Router();
+
+router.post(
+  '/users/register',
+  validator(schema.registerUser),
+  controllers.registerUser
+);
+
+module.exports = router;

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -3,11 +3,13 @@ const express = require('express');
 const controllers = require('../controllers/auth');
 const { validator } = require('../middlewares/validation');
 const schema = require('../schemas/auth');
+const { authorize } = require('../middlewares/authorization');
 
 const router = express.Router();
 
 router.post(
-  '/users/register',
+  '/_users',
+  authorize,
   validator(schema.registerUser),
   controllers.registerUser
 );

--- a/src/routes/rows.js
+++ b/src/routes/rows.js
@@ -4,33 +4,39 @@ const controllers = require('../controllers/rows');
 const { broadcast } = require('../middlewares/broadcast');
 const { validator } = require('../middlewares/validation');
 const schema = require('../schemas/rows');
+const { authorize } = require('../middlewares/authorization');
 
 const router = express.Router();
 
 router.get(
   '/:name/rows',
+  authorize,
   validator(schema.listTableRows),
   controllers.listTableRows
 );
 router.post(
   '/:name/rows',
+  authorize,
   validator(schema.insertRowInTable),
   controllers.insertRowInTable,
   broadcast
 );
 router.get(
   '/:name/rows/:pks',
+  authorize,
   validator(schema.getRowInTableByPK),
   controllers.getRowInTableByPK
 );
 router.put(
   '/:name/rows/:pks',
+  authorize,
   validator(schema.updateRowInTableByPK),
   controllers.updateRowInTableByPK,
   broadcast
 );
 router.delete(
   '/:name/rows/:pks',
+  authorize,
   validator(schema.deleteRowInTableByPK),
   controllers.deleteRowInTableByPK,
   broadcast

--- a/src/schemas/auth.js
+++ b/src/schemas/auth.js
@@ -1,0 +1,18 @@
+const Joi = require('joi');
+
+const registerUser = Joi.object({
+  query: Joi.object().required(),
+  params: Joi.object().required(),
+  body: Joi.object({
+    fields: Joi.object({
+      first_name: Joi.string().required(),
+      last_name: Joi.string().required(),
+      user_name: Joi.string().required(),
+      password: Joi.string().min(8).required()
+    }).required()
+  }).required()
+});
+
+module.exports = {
+  registerUser
+};

--- a/src/schemas/auth.js
+++ b/src/schemas/auth.js
@@ -8,7 +8,8 @@ const registerUser = Joi.object({
       first_name: Joi.string().required(),
       last_name: Joi.string().required(),
       user_name: Joi.string().required(),
-      password: Joi.string().min(8).required()
+      password: Joi.string().min(8).required(),
+      is_super_user: Joi.boolean().default(false)
     }).required()
   }).required()
 });

--- a/src/schemas/auth.js
+++ b/src/schemas/auth.js
@@ -25,7 +25,18 @@ const obtainAccessToken = Joi.object({
   }).required()
 });
 
+const refreshAccessToken = Joi.object({
+  query: Joi.object().required(),
+  params: Joi.object().required(),
+  body: Joi.object({
+    fields: Joi.object({
+      token: Joi.string().required()
+    }).required()
+  }).required()
+});
+
 module.exports = {
   registerUser,
-  obtainAccessToken
+  obtainAccessToken,
+  refreshAccessToken
 };

--- a/src/schemas/auth.js
+++ b/src/schemas/auth.js
@@ -13,6 +13,18 @@ const registerUser = Joi.object({
   }).required()
 });
 
+const obtainAccessToken = Joi.object({
+  query: Joi.object().required(),
+  params: Joi.object().required(),
+  body: Joi.object({
+    fields: Joi.object({
+      user_name: Joi.string().required(),
+      password: Joi.string().required()
+    }).required()
+  }).required()
+});
+
 module.exports = {
-  registerUser
+  registerUser,
+  obtainAccessToken
 };

--- a/src/services/rowService.js
+++ b/src/services/rowService.js
@@ -30,7 +30,6 @@ module.exports = (db) => {
     save(data) {
       // wrap text values in quotes
       const fieldsString = Object.keys(data.fields).join(', ');
-
       // wrap text values in quotes
       const valuesString = Object.values(data.fields).map((value) => value);
       const placeholders = Object.values(data.fields)
@@ -64,6 +63,6 @@ module.exports = (db) => {
       const statement = db.prepare(query);
       const result = statement.run(...pks);
       return result;
-    },
+    }
   };
 };

--- a/src/services/tableService.js
+++ b/src/services/tableService.js
@@ -1,5 +1,21 @@
 module.exports = (db) => {
   return {
-    get() {},
+    checkTableExists(tableName) {
+      const query = `SELECT name FROM sqlite_master WHERE type='table' AND name='${tableName}'`;
+      const result = db.prepare(query).get();
+      return result;
+    },
+
+    getTableNames() {
+      const query = `SELECT name FROM sqlite_master WHERE type='table'`;
+      const result = db.prepare(query).all();
+      return result;
+    },
+
+    createTable(tableName, columns) {
+      const columnDefinitions = columns.join(', ');
+      const query = `CREATE TABLE IF NOT EXISTS ${tableName} (${columnDefinitions});`;
+      db.exec(query);
+    }
   };
 };

--- a/src/utils/access_dictionary.js
+++ b/src/utils/access_dictionary.js
@@ -1,0 +1,6 @@
+module.exports = {
+  POST: 'can_create',
+  GET: 'can_read',
+  PUT: 'can_update',
+  DELETE: 'can_delete'
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,3 @@
+const accessDictinoary = require('./access_dictionary');
+
+module.exports = { accessDictinoary };


### PR DESCRIPTION
Fixes #138 

### Modifications 
**Default tables feature**
1. Added a function named `createDefaultPermissionTable` to create the `_default_permissions` table
2. Added a function in the `tableService` file to perform CRUD operations to tables 

**User register feature**
1. Added an API end-point `/users/register` to create users

**SignIn feature**
1. Added an API end-point `/token` to obtain access token

**Super user feature**
1. Added a feature to create a super user
   NOTE: For testing, you can pass the username and the password of the superuser to the `package.json` file
   ```
     npm run cli
   ```
**Authorization middleware**
1. Added an authorization middleware that checks if a user has permission to access a specific resource

**Unit Tests**
1. Added unit tests for authentication routes


