### PR TITLE
Change auth strategy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "soul-cli",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "soul-cli",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "bcrypt": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soul-cli",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A SQLite REST and Realtime server",
   "main": "src/server.js",
   "bin": {

--- a/src/commands.js
+++ b/src/commands.js
@@ -7,8 +7,7 @@ const runCLICommands = () => {
   // if the updatesuperuser command is passed from the CLI execute the updatesuperuser function
   if (argv._.includes('updatesuperuser')) {
     const { id, password, is_superuser } = argv;
-
-    if (!password && !is_superuser) {
+    if (!password && is_superuser === undefined) {
       console.log(
         'Please provide either the --password or --is_superuser flag when using the updateuser command.',
       );

--- a/src/controllers/auth/tables.js
+++ b/src/controllers/auth/tables.js
@@ -76,10 +76,10 @@ const createDefaultTables = async () => {
       permissions.push({
         role_id: roleId,
         table_name: table.name,
-        create: 'false',
-        read: 'true',
-        update: 'false',
-        delete: 'false',
+        create: 0,
+        read: 1,
+        update: 0,
+        delete: 0,
       });
     }
 

--- a/src/controllers/auth/token.js
+++ b/src/controllers/auth/token.js
@@ -55,7 +55,7 @@ const obtainAccessToken = async (req, res) => {
     */
     }
 
-    let permissions, roleIds;
+    let roleIds;
 
     // if the user is not a superuser get the role and its permission from the DB
     if (!toBoolean(user.is_superuser)) {
@@ -64,7 +64,6 @@ const obtainAccessToken = async (req, res) => {
         res,
       });
 
-      permissions = roleData.permissions;
       roleIds = roleData.roleIds;
     }
 
@@ -73,7 +72,6 @@ const obtainAccessToken = async (req, res) => {
       userId: user.id,
       isSuperuser: user.is_superuser,
       roleIds,
-      permissions,
     };
 
     // generate an access token
@@ -151,7 +149,7 @@ const refreshAccessToken = async (req, res) => {
     */
     }
 
-    let permissions, roleIds;
+    let roleIds;
     const user = users[0];
 
     // if the user is not a superuser get the role and its permission from the DB
@@ -161,7 +159,6 @@ const refreshAccessToken = async (req, res) => {
         res,
       });
 
-      permissions = roleData.permissions;
       roleIds = roleData.roleIds;
     }
 
@@ -170,7 +167,6 @@ const refreshAccessToken = async (req, res) => {
       userId: user.id,
       isSuperuser: user.is_superuser,
       roleIds,
-      permissions,
     };
 
     // generate an access token

--- a/src/controllers/auth/user.js
+++ b/src/controllers/auth/user.js
@@ -25,7 +25,7 @@ const updateSuperuser = async (fields) => {
 
   try {
     // find the user by using the id field
-    const users = authService.getRoleByUserId({ id });
+    const users = authService.getUsersById({ userId: id });
 
     // abort if the id is invalid
     if (users.length === 0) {

--- a/src/controllers/rows.js
+++ b/src/controllers/rows.js
@@ -657,7 +657,7 @@ const updateRowInTableByPK = async (req, res, next) => {
       if (typeof value === 'string') {
         value = `'${value}'`;
       }
-      return `${key} = ${value}`;
+      return `'${key}' = ${value}`;
     })
     .join(', ');
 

--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -48,9 +48,9 @@ const hasAccess = async (req, res, next) => {
         roleIds: payload.roleIds,
       });
 
-      const resourcePermission = rolePermissions.filter((row) => {
-        return row.table_name === tableName;
-      });
+      const resourcePermission = rolePermissions.filter(
+        (row) => row.table_name === tableName,
+      );
 
       if (resourcePermission.length <= 0) {
         return res

--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -1,6 +1,7 @@
 const config = require('../config');
 const { decodeToken, toBoolean } = require('../utils/index');
 const { apiConstants, responseMessages } = require('../constants');
+const { authService } = require('../services');
 
 const { errorMessage } = responseMessages;
 
@@ -42,12 +43,16 @@ const hasAccess = async (req, res, next) => {
           .send({ message: errorMessage.NOT_AUTHORIZED_ERROR });
       }
 
-      // if the user is not a super user, check the users permission on the resource
-      const permissions = payload.permissions.filter((row) => {
+      // if the user is not a super user, fetch the permission of the user from the DB
+      const rolePermissions = authService.getPermissionByRoleIds({
+        roleIds: payload.roleIds,
+      });
+
+      const resourcePermission = rolePermissions.filter((row) => {
         return row.table_name === tableName;
       });
 
-      if (permissions.length <= 0) {
+      if (resourcePermission.length <= 0) {
         return res
           .status(403)
           .send({ message: errorMessage.PERMISSION_NOT_DEFINED_ERROR });
@@ -56,7 +61,7 @@ const hasAccess = async (req, res, next) => {
       // If the user has permission on the table in at least in one of the roles then allow access on the table
       let hasPermission = false;
 
-      permissions.some((resource) => {
+      resourcePermission.some((resource) => {
         const httpMethod =
           apiConstants.httpMethodDefinitions[verb].toLowerCase();
 

--- a/src/middlewares/validation.js
+++ b/src/middlewares/validation.js
@@ -19,6 +19,24 @@ const validator = (schema) => (req, res, next) => {
   }
 };
 
+const customValidator = (schema) => (req) => {
+  const response = { errorStatus: false, message: '', error: '' };
+
+  const { body, params, query, cookies } = req;
+  const data = { body, params, query, cookies };
+
+  const { error } = schema.validate(data);
+
+  if (error) {
+    response.errorStatus = true;
+    response.message = error.message;
+    response.error = error.details;
+  }
+
+  return response;
+};
+
 module.exports = {
   validator,
+  customValidator,
 };

--- a/src/schemas/auth.js
+++ b/src/schemas/auth.js
@@ -59,9 +59,30 @@ const registerUser = Joi.object({
   }).required(),
 });
 
+const updateRolePermissions = Joi.object({
+  query: Joi.object({}).required(),
+  params: Joi.object({ name: Joi.string(), pks: Joi.string() }).required(),
+  body: Joi.object({
+    fields: Joi.object({
+      role_id: Joi.number().required(),
+      table_name: Joi.string().required(),
+      create: Joi.number().valid(0, 1).required(),
+      read: Joi.number().valid(0, 1).required(),
+      update: Joi.number().valid(0, 1).required(),
+      delete: Joi.number().valid(0, 1).required(),
+    }).required(),
+  }).required(),
+
+  cookies: Joi.object({
+    accessToken: Joi.string().required(),
+    refreshToken: Joi.string().optional(),
+  }).required(),
+});
+
 module.exports = {
   obtainAccessToken,
   refreshAccessToken,
   changePassword,
   registerUser,
+  updateRolePermissions,
 };


### PR DESCRIPTION
#173 

### Modifications 
1. Fixed error in the `updateSuperuser` function
2. Added quotes in the `updateRow` controller function to avoid errors that can be created by using reserved words like `create` and `update` in the SQL query
3. Added a validation schema in the `roles_permissoins` endpoint to only accept `0/1` values for the `create`, `read`, `update` and `delete` fields 
4. Changed the auth strategy and removed the users permission from the token

### Note

@thevahidal I saw a request to add a new API to see a users permission but we can use this endpoint to get permissions 

`/api/tables/_roles_permissions/rows?role_id`