### PR TITLE
Allow unknown fields to get passed via the cookie schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "soul-cli",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "soul-cli",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "MIT",
       "dependencies": {
         "bcrypt": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soul-cli",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "A SQLite REST and Realtime server",
   "main": "src/server.js",
   "bin": {

--- a/src/schemas/auth.js
+++ b/src/schemas/auth.js
@@ -14,7 +14,7 @@ const obtainAccessToken = Joi.object({
   cookies: Joi.object({
     refreshToken: Joi.string().optional(),
     accessToken: Joi.string().optional(),
-  }),
+  }).unknown(true),
 });
 
 const refreshAccessToken = Joi.object({
@@ -24,7 +24,9 @@ const refreshAccessToken = Joi.object({
   cookies: Joi.object({
     refreshToken: Joi.string().required(),
     accessToken: Joi.string().optional(),
-  }).required(),
+  })
+    .unknown(true)
+    .required(),
 });
 
 const changePassword = Joi.object({
@@ -40,7 +42,9 @@ const changePassword = Joi.object({
   cookies: Joi.object({
     accessToken: Joi.string().required(),
     refreshToken: Joi.string().optional(),
-  }).required(),
+  })
+    .unknown(true)
+    .required(),
 });
 
 const registerUser = Joi.object({
@@ -56,7 +60,9 @@ const registerUser = Joi.object({
   cookies: Joi.object({
     accessToken: Joi.string().required(),
     refreshToken: Joi.string().optional(),
-  }).required(),
+  })
+    .unknown(true)
+    .required(),
 });
 
 const updateRolePermissions = Joi.object({
@@ -76,7 +82,9 @@ const updateRolePermissions = Joi.object({
   cookies: Joi.object({
     accessToken: Joi.string().required(),
     refreshToken: Joi.string().optional(),
-  }).required(),
+  })
+    .unknown(true)
+    .required(),
 });
 
 const removeAccessTokens = Joi.object({
@@ -86,7 +94,9 @@ const removeAccessTokens = Joi.object({
   cookies: Joi.object({
     refreshToken: Joi.string().required(),
     accessToken: Joi.string().required(),
-  }).required(),
+  })
+    .unknown(true)
+    .required(),
 });
 
 module.exports = {


### PR DESCRIPTION
### Modifications 
1. The `Auth` schema is very tight and we are not allowing other fields in the `cookie` schema to be passed from the client, since some browsers might have some fields in the cookie, it would be better to set `unknown` to `true`