### PR TITLE
180 allow optional fields users table

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -2,7 +2,7 @@
 
 Soul incorporates a robust user authentication system that handles user accounts, groups, permissions, and cookie-based user sessions. This section provides an overview of how the default implementation works.
 
-Authentication is switched off by default in Soul, but is enabled when either of the `-a` or  `--auth` flags are provided at the command line.
+Authentication is switched off by default in Soul, but is enabled when either of the `-a` or `--auth` flags are provided at the command line.
 
 ### Overview
 
@@ -131,5 +131,7 @@ To register new users, you need to create a new user using the `/api/tables/_use
 Note that you need to be logged in using a user with a role that has creating users permission.
 
 Additionally, it's important to note that the `/api/tables/_users/rows/` endpoint functions slightly differently compared to other `/api/tables/<table_name>/rows/` endpoints. When creating or updating user data through this endpoint, we need to provide the raw passwords, which are then automatically hashed before being stored in the `_hashed_password` field. This extra step enhances the security of the stored passwords.
+
+When creating a user, the required fields are `username` and `password`. However, you also have the flexibility to include additional optional fields. To do this, you will need to modify the schema of the `_users` table in your database using a suitable database editor GUI tool. Simply add the desired field(s) to the database schema for the `_users` table. Once the schema is updated, you can pass the optional field(s) from your client application during user creation.
 
 Furthermore, when retrieving user data, the endpoint automatically filters out sensitive information such as the `_hashed_password` and `_salt` fields. This precautionary measure is in place to address security concerns and ensure that only necessary and non-sensitive information is included in the returned results.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "soul-cli",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "soul-cli",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "license": "MIT",
       "dependencies": {
         "bcrypt": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soul-cli",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "A SQLite REST and Realtime server",
   "main": "src/server.js",
   "bin": {

--- a/src/controllers/auth/user.js
+++ b/src/controllers/auth/user.js
@@ -92,7 +92,7 @@ const registerUser = async (req, res) => {
     }
   */
 
-  const { username, password } = req.body.fields;
+  const { username, password, ...optionalFields } = req.body.fields;
 
   try {
     if (!username) {
@@ -156,6 +156,7 @@ const registerUser = async (req, res) => {
         salt,
         hashed_password: hashedPassword,
         is_superuser: 'false',
+        ...optionalFields,
       },
     });
 


### PR DESCRIPTION
Fixes #180 

### Modifications 
1. Modify the `registerUser` controller to pass optional fields for the `POST /api/tables/_users/rows` endpoint

### Testing Results

1. A success message when we create a user with an optional field
   *  <img width="770" alt="Screen Shot 2024-04-23 at 4 57 48 PM" src="https://github.com/thevahidal/soul/assets/70259638/577a437f-12d5-4e4d-b8f1-d5995f5a7c47">

2. List of users that are returned when we send a request to the `GET /api/tables/_users/rows` endpoint
    *  ![Screen Shot 2024-04-23 at 4 59 24 PM](https://github.com/thevahidal/soul/assets/70259638/ee6f69c3-b7e1-4163-b8dc-9a5f93d7eaf8)

3. List of users in the database 
    * <img width="1012" alt="Screen Shot 2024-04-23 at 4 59 48 PM" src="https://github.com/thevahidal/soul/assets/70259638/3da34b61-bf18-47c9-9707-f6255e46f7b1">
    
4. A success message when we create a user without optional fields 
  * ![Screen Shot 2024-04-23 at 5 21 31 PM](https://github.com/thevahidal/soul/assets/70259638/af1ce33e-e570-4946-8e90-cff4c5e33703)
  * Note that this shows the feature is not breaking when we don't pass optional fields 

