### PR TITLE
Fix soul crashing error due to sending response with two res objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "soul-cli",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "soul-cli",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "license": "MIT",
       "dependencies": {
         "bcrypt": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soul-cli",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "A SQLite REST and Realtime server",
   "main": "src/server.js",
   "bin": {

--- a/src/controllers/auth/token.js
+++ b/src/controllers/auth/token.js
@@ -59,12 +59,18 @@ const obtainAccessToken = async (req, res) => {
 
     // if the user is not a superuser get the role and its permission from the DB
     if (!toBoolean(user.is_superuser)) {
-      const roleData = getUsersRoleAndPermission({
-        userId: user.id,
-        res,
-      });
+      try {
+        const roleData = getUsersRoleAndPermission({
+          userId: user.id,
+          res,
+        });
 
-      roleIds = roleData.roleIds;
+        roleIds = roleData.roleIds;
+      } catch (err) {
+        return res
+          .status(401)
+          .send({ message: errorMessage.ROLE_NOT_FOUND_ERROR });
+      }
     }
 
     const payload = {
@@ -162,12 +168,17 @@ const refreshAccessToken = async (req, res) => {
 
     // if the user is not a superuser get the role and its permission from the DB
     if (!toBoolean(user.is_superuser)) {
-      const roleData = getUsersRoleAndPermission({
-        userId: user.id,
-        res,
-      });
+      try {
+        const roleData = getUsersRoleAndPermission({
+          userId: user.id,
+        });
 
-      roleIds = roleData.roleIds;
+        roleIds = roleData.roleIds;
+      } catch (err) {
+        return res
+          .status(401)
+          .send({ message: errorMessage.ROLE_NOT_FOUND_ERROR });
+      }
     }
 
     const newPayload = {
@@ -271,11 +282,10 @@ const removeRevokedRefreshTokens = () => {
   });
 };
 
-const getUsersRoleAndPermission = ({ userId, res }) => {
+const getUsersRoleAndPermission = ({ userId }) => {
   const userRoles = authService.getUserRoleByUserId({ userId });
 
   if (userRoles <= 0) {
-    res.status(401).send({ message: errorMessage.ROLE_NOT_FOUND_ERROR });
     throw new Error(errorMessage.ROLE_NOT_FOUND_ERROR);
   }
 

--- a/src/controllers/auth/token.js
+++ b/src/controllers/auth/token.js
@@ -285,7 +285,7 @@ const removeRevokedRefreshTokens = () => {
 const getUsersRoleAndPermission = ({ userId }) => {
   const userRoles = authService.getUserRoleByUserId({ userId });
 
-  if (userRoles <= 0) {
+  if (userRoles.length <= 0) {
     throw new Error(errorMessage.ROLE_NOT_FOUND_ERROR);
   }
 


### PR DESCRIPTION
Fixes #182 

## Modifications 
1. Modified the `obtainAccessToken` and the `refreshAccessToken` functions to avoid returning multiple response with the `res` object
2. Modified the `getRolesAndPermission` function to no longer modify the response object

## Testing Results

Previously, when a user without a role attempted to login, Soul was returning a Success message to the client. However, it has been modified to return the following error message instead:

<img width="1010" alt="Screen Shot 2024-04-26 at 11 56 34 AM" src="https://github.com/thevahidal/soul/assets/70259638/453b222f-e161-4fa9-965c-be41bd12af2c">
