### PR TITLE
Feature to pass `.env` file path from the `CLI`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Options:
   -p,       --port                                  Port to listen on                                   [number]
   -r,       --rate-limit-enabled                    Enable rate limiting                                [boolean]
   -c,       --cors                                  CORS whitelist origins                              [string]
+  --env,    --envpath                               Path to load .env file                              [string]
   -a,       --auth                                  Enable authentication and authorization             [boolean]
 
   --iuu,     --initialuserusername                   Initial user username                               [string]
@@ -42,8 +43,8 @@ Options:
   --ts,      --tokensecret                           Token Secret                                        [string]
   --atet,    --accesstokenexpirationtime             Access Token Expiration Time    (Default: 5H)       [string]
   --rtet,    --refreshtokenexpirationtime            Refresh Token Expiration Time   (Default: 1D)       [string]
-  -S,       --studio                                Start Soul Studio in parallel
-  --help                                            Show help
+  -S,       --studio                                 Start Soul Studio in parallel
+  --help                                             Show help
 
 ```
 
@@ -97,6 +98,20 @@ soul -d foobar.db updatesuperuser --id=1 --is_superuser=true // Upgrade the user
 
 soul -d foobar.db updatesuperuser --id=1 --is_superuser=false // Revoke the superuser role from the superuser with ID 1
 ```
+
+### Passing Custom Path for .env File
+
+There might be cases where you want to pass a custom path for your `.env` file. For this, you can use the `--env` flag when running the `soul` command, providing the absolute file path of your `.env` file.
+
+```shell
+soul -d foobar.db --env=/Users/Documents/Projects/React-Project/.env
+```
+
+NOTE:
+
+- You should pass an absolute file path of the .env file.
+- Relative paths are not allowed.
+- Don't forget to include the .env file in the specified path.
 
 ## Documentation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "soul-cli",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "soul-cli",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "license": "MIT",
       "dependencies": {
         "bcrypt": "^5.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "soul-cli",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "soul-cli",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "license": "MIT",
       "dependencies": {
         "bcrypt": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soul-cli",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "A SQLite REST and Realtime server",
   "main": "src/server.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soul-cli",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "A SQLite REST and Realtime server",
   "main": "src/server.js",
   "bin": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -46,6 +46,12 @@ if (process.env.NO_CLI !== 'true') {
       type: 'string',
       demandOption: false,
     })
+    .options('env', {
+      alias: 'envpath',
+      describe: 'Environment variable file path to load',
+      type: 'string',
+      demandOption: false,
+    })
     .options('a', {
       alias: 'auth',
       describe: 'Enable authentication and authorization',

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -6,7 +6,7 @@ const { yargs } = require('../cli');
 
 const { argv } = yargs;
 
-dotenv.config({ path: path.join(__dirname, '../../.env') });
+dotenv.config({ path: argv.envpath || path.join(__dirname, '../../.env') });
 
 const envVarsSchema = Joi.object()
   .keys({


### PR DESCRIPTION
Fixes #188 

### Modification

1. Added a feature to pass `.env` file path from the `CLI` 