### PR TITLE
Add documentation for the custom .env file & modify Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ soul -d foobar.db updatesuperuser --id=1 --is_superuser=false // Revoke the supe
 There might be cases where you want to pass a custom path for your `.env` file. For this, you can use the `--env` flag when running the `soul` command, providing the absolute file path of your `.env` file.
 
 ```shell
-soul -d foobar.db --env=/Users/Documents/Projects/React-Project/.env
+soul -d foobar.db --env=/absolute/path/of/your/.env/file
 ```
 
 NOTE:

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -135,3 +135,9 @@ Additionally, it's important to note that the `/api/tables/_users/rows/` endpoin
 When creating a user, the required fields are `username` and `password`. However, you also have the flexibility to include additional optional fields. To do this, you will need to modify the schema of the `_users` table in your database using a suitable database editor GUI tool. Simply add the desired field(s) to the database schema for the `_users` table. Once the schema is updated, you can pass the optional field(s) from your client application during user creation.
 
 Furthermore, when retrieving user data, the endpoint automatically filters out sensitive information such as the `_hashed_password` and `_salt` fields. This precautionary measure is in place to address security concerns and ensure that only necessary and non-sensitive information is included in the returned results.
+
+#### Revoked Refresh Tokens
+
+When you send a request to log in to Soul using the `/token/obtain` endpoint, you will receive `Access` and `Refresh` tokens. These tokens can be stored in a secure client environment. You can then send a request to the `/token/refresh` endpoint to refresh your access token when it expires.
+
+When you log out of Soul, the `Access` and `Refresh` tokens are removed. However, there might be instances where you log out before the refresh token expires, allowing these tokens to be reused by other users. To handle this issue, Soul saves removed refresh tokens temporarily in a table named `revoked_access_tokens`. Each time you attempt to refresh your access token, Soul checks if the `Refresh` token you are using is valid. If you try to reuse a revoked refresh token, Soul will throw an error.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "soul-cli",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "soul-cli",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "license": "MIT",
       "dependencies": {
         "bcrypt": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soul-cli",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "A SQLite REST and Realtime server",
   "main": "src/server.js",
   "bin": {


### PR DESCRIPTION
Fixes #190 

### Modifications 
1. Modified the `README` file to show users on how to pass an `absolute path` for the `custom` `.env` file
2. Added a documentation for the `Revoked Refresh Tokens` in the `docs` folder