### PR TITLE
Fix test configuration for auth tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "npm run swagger-autogen && cross-env NO_CLI=true nodemon src/server.js",
     "cli": "nodemon src/server.js --database foobar.db",
     "swagger-autogen": "cross-env NO_CLI=true node src/swagger/index.js",
-    "test": "cross-env CI=true NODE_ENV=test NO_CLI=true DB=test.db CORE_PORT=8001 jest --testTimeout=10000",
+    "test": "cross-env CI=true NODE_ENV=test NO_CLI=true DB=test.db CORE_PORT=8001 AUTH=true TOKEN_SECRET=test-secret INITIAL_USER_USERNAME=admin INITIAL_USER_PASSWORD=Admin123#Test jest --testTimeout=10000 --forceExit",
     "prepare": "husky install",
     "lint": "eslint . --fix --max-warnings=0",
     "format": "prettier . --write"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soul-cli",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "A SQLite REST and Realtime server",
   "main": "src/server.js",
   "bin": {

--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,7 @@ if (config.auth) {
 setInterval(
   removeRevokedRefreshTokens,
   authConstants.REVOKED_REFRESH_TOKENS_REMOVAL_TIME_RANGE,
-);
+).unref();
 
 // If the user has passed custom CLI commands run the command and exit to avoid running the server
 runCLICommands();

--- a/src/swagger/swagger.json
+++ b/src/swagger/swagger.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "0.8.1",
+    "version": "0.8.3",
     "title": "Soul API",
     "description": "API Documentation for <b>Soul</b>, a SQLite REST and realtime server. "
   },


### PR DESCRIPTION
## Summary
- Enable auth mode in test configuration with required env vars (AUTH, TOKEN_SECRET, initial user credentials)
- Add `--forceExit` to Jest for clean test exit
- Add `.unref()` to token cleanup interval to prevent blocking process exit
- Bump version to 0.8.3 (also syncs swagger.json which was at 0.8.1)

## Test plan
- [x] All 35 unit tests pass
- [x] No worker process exit warnings